### PR TITLE
zabbix agent: do not cache the server's InetAddress internally, allow…

### DIFF
--- a/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/ZabbixAgent.java
+++ b/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/ZabbixAgent.java
@@ -85,14 +85,16 @@ public class ZabbixAgent {
 
         if(enableActive) {
         	if(log.isInfoEnabled()) {
-        		log.info("Starting active agent.");
+        		log.info("Starting active agent with {}", serverAddress);
         	}
+
+        	InetAddress addr = InetAddress.getByName(serverAddress); // make sure it can be resolved
 
         	activeThread = new ActiveThread(metricsContainer, hostName, serverAddress, serverPort, refreshInterval, pskIdentity, psk);
         	activeThread.start();
 
         	if(log.isInfoEnabled()) {
-        		log.info("Active agent started.");
+        		log.info("Active agent started with {}", addr);
         	}
         }
 
@@ -243,7 +245,7 @@ public class ZabbixAgent {
 	 * Return the value of property <code>serverAddress</code>.
 	 * @return the current value of <code>serverAddress</code>.
 	 */
-	public InetAddress getServerAddress() {
+	public String getServerAddress() {
 		return serverAddress;
 	}
 
@@ -251,7 +253,7 @@ public class ZabbixAgent {
 	 * Set the value of property <code>serverAddress</code>.
 	 * @param serverAddress the IP address for the Zabbix server listening for active checks.
 	 */
-	public void setServerAddress(InetAddress serverAddress) {
+	public void setServerAddress(String serverAddress) {
 		this.serverAddress = serverAddress;
 	}
 
@@ -324,7 +326,7 @@ public class ZabbixAgent {
 
     private boolean enableActive;
     private String hostName;
-    private InetAddress serverAddress;
+    private String serverAddress;
     private int serverPort;
     private int refreshInterval;
     private String pskIdentity;

--- a/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/active/ActiveThread.java
+++ b/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/active/ActiveThread.java
@@ -43,7 +43,7 @@ import com.quigley.zabbixj.ZabbixException;
 import com.quigley.zabbixj.metrics.MetricsContainer;
 
 public class ActiveThread extends Thread {
-	public ActiveThread(MetricsContainer metricsContainer, String hostName, InetAddress serverAddress, int serverPort, int refreshInterval, String pskIdentity, String psk) {
+	public ActiveThread(MetricsContainer metricsContainer, String hostName, String serverAddress, int serverPort, int refreshInterval, String pskIdentity, String psk) {
 		running = true;
 		checks = new HashMap<Integer, List<String>>();
 		lastChecked = new HashMap<Integer, Long>();
@@ -407,7 +407,7 @@ public class ActiveThread extends Thread {
 	
 	private MetricsContainer metricsContainer;
 	private String hostName;
-	private InetAddress serverAddress;
+	private String serverAddress;
 	private int serverPort;
 	private int refreshInterval;
 	private String pskIdentity;

--- a/zabbixj-examples/src/main/java/com/quigley/zabbixj/examples/ExampleActiveAgent.java
+++ b/zabbixj-examples/src/main/java/com/quigley/zabbixj/examples/ExampleActiveAgent.java
@@ -15,8 +15,6 @@
  */
 package com.quigley.zabbixj.examples;
 
-import java.net.InetAddress;
-
 import com.quigley.zabbixj.agent.ZabbixAgent;
 import com.quigley.zabbixj.providers.JVMMetricsProvider;
 
@@ -40,7 +38,7 @@ public class ExampleActiveAgent {
 		agent.setEnableActive(true);
 		agent.setEnablePassive(false);
 		agent.setHostName(hostName);
-		agent.setServerAddress(InetAddress.getByName(serverAddress));
+		agent.setServerAddress(serverAddress);
 		agent.setServerPort(serverPort);
 		
         agent.addProvider("example", new ExampleMetricsProvider());


### PR DESCRIPTION
… re-resolve from time to time

In our environment we noticed that microservices using the Zabbix active Agent would lose track
of Zabbix Proxy when we replaced the proxy instance (which makes IP address to change).

The reason is InetAddress caches the resolved IP internally. The appropriate way is let
agent call InetAddress.getByName() often (because internally they cache the results,
and maintain appropriate TTL) - so that environment DNS changes are properly reflected.

It seems by letting ActiveThread use the Socket(String host, int port) constructor, the Socket class will do the right thing (resolve as appropriate, etc).