### PR TITLE
zabbix agent: set panic on not existed provider optionally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+**/out/
 .gradle
 .classpath
 .project

--- a/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/ZabbixAgent.java
+++ b/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/ZabbixAgent.java
@@ -42,6 +42,8 @@ public class ZabbixAgent {
      * @throws Exception when a problem occurs creating the agent.
      */
     public ZabbixAgent() throws Exception {
+        failOnNotExistedMetricProvider = true;
+
         metricsContainer = new MetricsContainer();
 
         enablePassive = true;
@@ -308,6 +310,17 @@ public class ZabbixAgent {
 	}
 
 	/**
+	 * Return the value of property <code>failOnNotExistedMetricProvider</code>.
+	 * @return the current value of the <code>failOnNotExistedMetricProvider</code> property. Defaults to <code>true</code>.
+	 */
+	public boolean isFailOnNotExistedMetricProvider() {
+		return failOnNotExistedMetricProvider;
+	}
+	public void setFailOnNotExistedMetricProvider(boolean failOnNotExistedMetricProvider) {
+		this.failOnNotExistedMetricProvider = failOnNotExistedMetricProvider;
+	}
+
+	/**
      * Add a MetricsProvider to the agent.
      * @param name bind the provider to this name.
      * @param provider the provider instance.
@@ -325,6 +338,7 @@ public class ZabbixAgent {
     private int listenPort;
 
     private boolean enableActive;
+    private boolean failOnNotExistedMetricProvider;
     private String hostName;
     private String serverAddress;
     private int serverPort;

--- a/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/active/ActiveThread.java
+++ b/zabbixj-core/src/main/java/com/quigley/zabbixj/agent/active/ActiveThread.java
@@ -281,6 +281,10 @@ public class ActiveThread extends Thread {
 			key.put("key", keyName);
 			try {
 				Object value = metricsContainer.getMetric(keyName);
+				if (value == null) {
+					// skip null values, it means not need report ZBX_NOTSUPPORTED to zabbix
+					continue;
+				}
 				key.put("value", value.toString());
 				
 			} catch(Exception e) {

--- a/zabbixj-core/src/main/java/com/quigley/zabbixj/metrics/MetricsContainer.java
+++ b/zabbixj-core/src/main/java/com/quigley/zabbixj/metrics/MetricsContainer.java
@@ -25,7 +25,12 @@ import org.slf4j.LoggerFactory;
 
 public class MetricsContainer {
 	public MetricsContainer() {
-		container = new HashMap<String, MetricsProvider>();
+		this(true);
+	}
+
+	public MetricsContainer(boolean failOnNotExistedMetricProvider) {
+		this.container = new HashMap<String, MetricsProvider>();
+		this.failOnNotExistedMetricProvider = failOnNotExistedMetricProvider;
 	}
 
 	/**
@@ -76,8 +81,10 @@ public class MetricsContainer {
 	public MetricsProvider getProvider(String name) throws MetricsException {
 		if(container.containsKey(name)) {
 			return (MetricsProvider) container.get(name);
-		} else {
+		} else if (failOnNotExistedMetricProvider) {
 			throw new MetricsException("No MetricsProvider with name: " + name);
+		} else {
+			return null;
 		}
 	}	
 
@@ -90,10 +97,12 @@ public class MetricsContainer {
 	public Object getMetric(String key) throws MetricsException {
 		MetricsKey mk = new MetricsKey(key);
 		MetricsProvider provider = getProvider(mk.getProvider());
-		return provider.getValue(mk);
+		return provider == null? null : provider.getValue(mk);
 	}
 
 	private Map<String, MetricsProvider> container;
+
+    private boolean failOnNotExistedMetricProvider;
 
     private static Logger log = LoggerFactory.getLogger(MetricsProvider.class);
 }

--- a/zabbixj-core/src/test/java/com/quigley/zabbixj/metrics/MetricsContainerTest.java
+++ b/zabbixj-core/src/test/java/com/quigley/zabbixj/metrics/MetricsContainerTest.java
@@ -1,0 +1,43 @@
+package com.quigley.zabbixj.metrics;
+
+import org.junit.Test;
+
+public class MetricsContainerTest {
+
+    @Test(expected = MetricsException.class)
+    public void testGetProvider_1() {
+        MetricsContainer c = new MetricsContainer();
+        c.getMetric("provider.some_key");
+    }
+
+    @Test
+    public void testGetProvider_2() {
+        MetricsContainer c = new MetricsContainer(false);
+        c.getMetric("provider.some_key");
+    }
+
+    @Test
+    public void testGetMetric_1() {
+        MetricsContainer c = new MetricsContainer(false);
+        c.addProvider("provider", new MetricsProvider() {
+            @Override
+            public Object getValue(MetricsKey mKey) throws MetricsException {
+                return null;
+            }
+        });
+        c.getMetric("provider.some_key");
+        c.getMetric("other.some_key");
+    }
+
+    @Test(expected = MetricsException.class)
+    public void testGetMetric_2() {
+        MetricsContainer c = new MetricsContainer();
+        c.addProvider("provider", new MetricsProvider() {
+            @Override
+            public Object getValue(MetricsKey mKey) throws MetricsException {
+                throw new MetricsException();
+            }
+        });
+        c.getMetric("provider.some_key");
+    }
+}


### PR DESCRIPTION
Add use case support:
On same host (zabbix node) running more than one agent applications and sending different data to zabbix (I mean different metric providers). 